### PR TITLE
Fixed TWR (Current) to account for vessel altitude

### DIFF
--- a/Engineer/FlightEngineer.cs
+++ b/Engineer/FlightEngineer.cs
@@ -130,7 +130,7 @@ namespace Engineer
                     {
                         stages = SimManager.Instance.Stages;
                     }
-                    SimManager.Instance.Gravity = this.vessel.mainBody.gravParameter / Math.Pow(this.vessel.mainBody.Radius, 2);
+                    SimManager.Instance.Gravity = this.vessel.mainBody.gravParameter / Math.Pow(this.vessel.mainBody.Radius + this.vessel.mainBody.GetAltitude(this.vessel.CoM), 2);
                     SimManager.Instance.TryStartSimulation();
                     isActive = true;
                 }


### PR DESCRIPTION
Hi Cybutek! Love Kerbal Engineer, I just started using it and it's awesome. One of the things that I noticed is that the Current and Surface thrust-to-weight ratio displays both show the Surface value. Here's a little fix for that, it just adds the vessel's altitude to the main body's radius in the Gravity field for the SimManager.
